### PR TITLE
add/use esc.empty() to return the "right" checksum value for cells th…

### DIFF
--- a/esctest/esc.py
+++ b/esctest/esc.py
@@ -18,6 +18,19 @@ ST = ESC + "\\"
 # VT x00 level. vtLevel may be 1, 2, 3, 4, or 5.
 vtLevel = 1
 
+# xterm distinguishes "blanks" (cells where a space was written) from empty
+# space (after an erase) to use that in selection.  DEC's documentation does
+# not have anything analogous.  These scripts use DECRQCRA to guess what a
+# given cell contains, and make the assumption that a NUL corresponds to the
+# latter.  However, xterm patch #334 changes DECRQCRA for better consistency
+# with the documentation, and computes empty and blank cells as if both hold
+# a space.
+def empty():
+  if escargs.args.expected_terminal == "xterm":
+    return ' '
+  else:
+    return NUL
+
 def blank():
   if escargs.args.expected_terminal == "xterm":
     return ' '

--- a/esctest/esccmd.py
+++ b/esctest/esccmd.py
@@ -387,8 +387,6 @@ def DECRC():
 def DECRQCRA(Pid, Pp=None, rect=None):
   """Compute the checksum (16-bit sum of ordinals) in a rectangle."""
   AssertVTLevel(4, "DECRQCRA")
-  if escargs.args.expected_terminal == "xterm":
-    Pid, Pp = Pp, Pid
 
   params = [Pid]
 

--- a/esctest/tests/apc.py
+++ b/esctest/tests/apc.py
@@ -1,4 +1,4 @@
-from esc import NUL, ST, S7C1T, S8C1T
+from esc import empty, ST, S7C1T, S8C1T
 import escargs
 import esccmd
 import escio
@@ -14,7 +14,7 @@ class APCTests(object):
     escio.Write("A")
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 1),
-                                 ["A" + NUL * 2])
+                                 ["A" + empty() * 2])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="8-bit controls not implemented.")
@@ -32,5 +32,5 @@ class APCTests(object):
     escio.use8BitControls = False
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 1),
-                                 ["A" + NUL * 2])
+                                 ["A" + empty() * 2])
 

--- a/esctest/tests/dch.py
+++ b/esctest/tests/dch.py
@@ -1,4 +1,4 @@
-from esc import NUL
+from esc import empty
 import esccmd
 import escio
 from esctypes import Point, Rect
@@ -11,7 +11,7 @@ class DCHTests(object):
     escio.Write("abcd")
     esccmd.CUP(Point(2, 1))
     esccmd.DCH()
-    AssertScreenCharsInRectEqual(Rect(1, 1, 4, 1), ["acd" + NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 4, 1), ["acd" + empty()])
 
   @vtLevel(4)
   def test_DCH_ExplicitParam(self):
@@ -19,7 +19,7 @@ class DCHTests(object):
     escio.Write("abcd")
     esccmd.CUP(Point(2, 1))
     esccmd.DCH(2)
-    AssertScreenCharsInRectEqual(Rect(1, 1, 4, 1), ["ad" + NUL * 2])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 4, 1), ["ad" + empty() * 2])
 
   @vtLevel(4)
   def test_DCH_RespectsMargins(self):
@@ -31,7 +31,7 @@ class DCHTests(object):
     esccmd.DCH()
     esccmd.DECRESET(esccmd.DECLRMM)
 
-    AssertScreenCharsInRectEqual(Rect(1, 1, 5, 1), ["abd" + NUL + "e"])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 5, 1), ["abd" + empty() + "e"])
 
   @vtLevel(4)
   def test_DCH_DeleteAllWithMargins(self):
@@ -43,7 +43,7 @@ class DCHTests(object):
     esccmd.DCH(99)
     esccmd.DECRESET(esccmd.DECLRMM)
 
-    AssertScreenCharsInRectEqual(Rect(1, 1, 5, 1), ["ab" + NUL * 2 + "e"])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 5, 1), ["ab" + empty() * 2 + "e"])
 
   @vtLevel(4)
   def test_DCH_DoesNothingOutsideLeftRightMargin(self):
@@ -67,4 +67,4 @@ class DCHTests(object):
     esccmd.DCH(99)
     esccmd.DECSTBM()
 
-    AssertScreenCharsInRectEqual(Rect(1, 1, 5, 1), [NUL * 5])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 5, 1), [empty() * 5])

--- a/esctest/tests/dcs.py
+++ b/esctest/tests/dcs.py
@@ -1,4 +1,4 @@
-from esc import NUL
+from esc import empty
 import escio
 from escutil import AssertScreenCharsInRectEqual, vtLevel
 from esctypes import Rect
@@ -8,5 +8,5 @@ class DCSTests(object):
   def test_DCS_Unrecognized(self):
     """An unrecognized DCS code should be swallowed"""
     escio.WriteDCS("z", "0")
-    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 1), NUL)
+    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 1), empty())
 

--- a/esctest/tests/decdc.py
+++ b/esctest/tests/decdc.py
@@ -14,7 +14,7 @@ Only that portion of the display between the top, bottom, left, and right
 margins is affected.  DECDC is ignored if the active position is outside the
 Scroll Area.
 """
-from esc import NUL, CR, LF
+from esc import empty, CR, LF
 import esccmd
 import escio
 from escutil import AssertEQ, GetCursorPosition, GetScreenSize, AssertScreenCharsInRectEqual, knownBug, vtLevel
@@ -33,8 +33,8 @@ class DECDCTests(object):
     esccmd.DECDC()
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 7, 2),
-                                 ["acdefg" + NUL,
-                                  "ACDEFG" + NUL])
+                                 ["acdefg" + empty(),
+                                  "ACDEFG" + empty()])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="Not implemented")
@@ -49,9 +49,9 @@ class DECDCTests(object):
     esccmd.DECDC(2)
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 7, 3),
-                                 ["adefg" + NUL * 2,
-                                  "ADEFG" + NUL * 2,
-                                  "zwvut" + NUL * 2])
+                                 ["adefg" + empty() * 2,
+                                  "ADEFG" + empty() * 2,
+                                  "zwvut" + empty() * 2])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="Not implemented")
@@ -76,8 +76,8 @@ class DECDCTests(object):
     esccmd.DECRESET(esccmd.DECLRMM)
     AssertScreenCharsInRectEqual(Rect(1, 1, 7, 4),
                                  ["abcdefg",
-                                  "ADEFG" + NUL * 2,
-                                  "zwvut" + NUL * 2,
+                                  "ADEFG" + empty() * 2,
+                                  "zwvut" + empty() * 2,
                                   "ZYXWVUT"])
 
   @vtLevel(4)
@@ -123,10 +123,10 @@ class DECDCTests(object):
     esccmd.DECDC(width + 10)
 
     AssertScreenCharsInRectEqual(Rect(startX, 1, width, 2),
-                                 ["a" + NUL * 6,
-                                  "A" + NUL * 6])
+                                 ["a" + empty() * 6,
+                                  "A" + empty() * 6])
     # Ensure there is no wrap-around.
-    AssertScreenCharsInRectEqual(Rect(1, 2, 1, 3), [NUL, NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 2, 1, 3), [empty(), empty()])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="Not implemented")
@@ -151,8 +151,8 @@ class DECDCTests(object):
     # Ensure the 'e' gets dropped.
     esccmd.DECRESET(esccmd.DECLRMM)
     AssertScreenCharsInRectEqual(Rect(1, 1, 7, 2),
-                                 ["abde" + NUL + "fg",
-                                  "ABDE" + NUL + "FG"])
+                                 ["abde" + empty() + "fg",
+                                  "ABDE" + empty() + "FG"])
 
 
   @vtLevel(4)
@@ -177,7 +177,7 @@ class DECDCTests(object):
 
     esccmd.DECRESET(esccmd.DECLRMM)
     AssertScreenCharsInRectEqual(Rect(1, 1, 7, 2),
-                                 ["ab" + NUL * 3 + "fg",
-                                  "AB" + NUL * 3 + "FG"])
+                                 ["ab" + empty() * 3 + "fg",
+                                  "AB" + empty() * 3 + "FG"])
 
 

--- a/esctest/tests/decfi.py
+++ b/esctest/tests/decfi.py
@@ -19,7 +19,7 @@ If the active position is outside the left or right margin when the command is
 received the active position moves forward one column.  If the active position
 was at the right edge of the page, the command is ignored.
 """
-from esc import NUL
+from esc import empty
 import esccmd
 import escio
 from escutil import AssertEQ, AssertScreenCharsInRectEqual, GetCursorPosition, GetScreenSize, Point, Rect, intentionalDeviationFromSpec, knownBug, vtLevel
@@ -62,14 +62,11 @@ class DECFITests(object):
     esccmd.CUP(Point(5, 5))
     esccmd.DECFI()
 
-    # It is out of character for xterm to use NUL in the middle of the line,
-    # but not terribly important, and not worth marking as a bug. I mentioned
-    # it to TED.
     AssertScreenCharsInRectEqual(Rect(2, 3, 6, 7),
                                  ["abcde",
-                                  "fhi" + NUL + "j",
-                                  "kmn" + NUL + "o",
-                                  "prs" + NUL + "t",
+                                  "fhi" + empty() + "j",
+                                  "kmn" + empty() + "o",
+                                  "prs" + empty() + "t",
                                   "uvwxy"])
 
   @vtLevel(4)
@@ -92,4 +89,4 @@ class DECFITests(object):
     escio.Write("x")
     esccmd.DECFI()
     AssertScreenCharsInRectEqual(Rect(size.width() - 1, 1, size.width(), 1),
-                                 ["x" + NUL])
+                                 ["x" + empty()])

--- a/esctest/tests/decic.py
+++ b/esctest/tests/decic.py
@@ -1,4 +1,4 @@
-from esc import NUL, CR, LF, blank
+from esc import CR, LF, empty, blank
 import esccmd
 import escio
 from escutil import AssertEQ, GetCursorPosition, GetScreenSize, AssertScreenCharsInRectEqual, knownBug, vtLevel
@@ -60,10 +60,10 @@ class DECICTests(object):
     esccmd.DECSTBM()
     esccmd.DECRESET(esccmd.DECLRMM)
     AssertScreenCharsInRectEqual(Rect(1, 1, 9, 4),
-                                 ["abcdefg" + NUL * 2,
+                                 ["abcdefg" + empty() * 2,
                                   "A" + blank() * 2 + "BCDEFG",
                                   "z" + blank() * 2 + "yxwvut",
-                                  "ZYXWVUT" + NUL * 2])
+                                  "ZYXWVUT" + empty() * 2])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="Not implemented", noop=True)
@@ -107,7 +107,7 @@ class DECICTests(object):
                                  ["a" + blank() + "bcdef",
                                   "A" + blank() + "BCDEF"])
     # Ensure there is no wrap-around.
-    AssertScreenCharsInRectEqual(Rect(1, 2, 1, 3), [NUL, NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 2, 1, 3), [empty(), empty()])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="Not implemented")

--- a/esctest/tests/decscl.py
+++ b/esctest/tests/decscl.py
@@ -1,4 +1,4 @@
-from esc import NUL
+from esc import empty
 import esccmd
 import escio
 from escutil import AssertEQ, AssertScreenCharsInRectEqual, AssertTrue, GetCursorPosition, GetScreenSize, knownBug, vtLevel
@@ -70,7 +70,7 @@ class DECSCLTests(object):
     esccmd.CUP(Point(1, 1))
     escio.Write("1")
     esccmd.DECSET(esccmd.DECCOLM)
-    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 1), [NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 1), [empty()])
 
     # Make sure DECSLRM succeeds.
     esccmd.DECSET(esccmd.DECLRMM)
@@ -116,7 +116,7 @@ class DECSCLTests(object):
     esccmd.SM(esccmd.IRM)
 
     esccmd.DECSCL(61)
-    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 1), [NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 1), [empty()])
 
     # Ensure saved cursor position is the origin
     esccmd.DECRC()

--- a/esctest/tests/decsed.py
+++ b/esctest/tests/decsed.py
@@ -1,4 +1,4 @@
-from esc import NUL, blank
+from esc import empty, blank
 import esccmd
 import escio
 from escutil import AssertScreenCharsInRectEqual, knownBug, vtLevel
@@ -49,11 +49,11 @@ class DECSEDTests(object):
     self.prepare()
     esccmd.DECSED()
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 5),
-                                 ["a" + NUL * 2,
-                                  NUL * 3,
-                                  "b" + NUL * 2,
-                                  NUL * 3,
-                                  NUL * 3])
+                                 ["a" + empty() * 2,
+                                  empty() * 3,
+                                  "b" + empty() * 2,
+                                  empty() * 3,
+                                  empty() * 3])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="DECSED not implemented")
@@ -62,11 +62,11 @@ class DECSEDTests(object):
     self.prepare()
     esccmd.DECSED(0)
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 5),
-                                 ["a" + NUL * 2,
-                                  NUL * 3,
-                                  "b" + NUL * 2,
-                                  NUL * 3,
-                                  NUL * 3])
+                                 ["a" + empty() * 2,
+                                  empty() * 3,
+                                  "b" + empty() * 2,
+                                  empty() * 3,
+                                  empty() * 3])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="DECSED not implemented")
@@ -75,11 +75,11 @@ class DECSEDTests(object):
     self.prepare()
     esccmd.DECSED(1)
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 5),
-                                 [NUL * 3,
-                                  NUL * 3,
+                                 [empty() * 3,
+                                  empty() * 3,
                                   blank() * 2 + "d",
-                                  NUL * 3,
-                                  "e" + NUL * 2])
+                                  empty() * 3,
+                                  "e" + empty() * 2])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="DECSED not implemented")
@@ -88,11 +88,11 @@ class DECSEDTests(object):
     self.prepare()
     esccmd.DECSED(2)
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 5),
-                                 [NUL * 3,
-                                  NUL * 3,
-                                  NUL * 3,
-                                  NUL * 3,
-                                  NUL * 3])
+                                 [empty() * 3,
+                                  empty() * 3,
+                                  empty() * 3,
+                                  empty() * 3,
+                                  empty() * 3])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="DECSED not implemented", noop=True)
@@ -104,11 +104,11 @@ class DECSEDTests(object):
     esccmd.DECSED(3)
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 5),
-                                 ["a" + NUL * 2,
-                                  NUL * 3,
+                                 ["a" + empty() * 2,
+                                  empty() * 3,
                                   "bcd",
-                                  NUL * 3,
-                                  "e" + NUL * 2])
+                                  empty() * 3,
+                                  "e" + empty() * 2])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="DECSED not implemented")
@@ -124,8 +124,8 @@ class DECSEDTests(object):
     esccmd.DECSTBM()
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 3),
                                  ["abcde",
-                                  "fg" + NUL * 3,
-                                  NUL * 5])
+                                  "fg" + empty() * 3,
+                                  empty() * 5])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="DECSED not implemented")
@@ -140,7 +140,7 @@ class DECSEDTests(object):
     esccmd.DECRESET(esccmd.DECLRMM)
     esccmd.DECSTBM()
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 3),
-                                 [NUL * 5,
+                                 [empty() * 5,
                                   blank() * 3 + "ij",
                                   "klmno"])
 
@@ -157,9 +157,9 @@ class DECSEDTests(object):
     esccmd.DECRESET(esccmd.DECLRMM)
     esccmd.DECSTBM()
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 3),
-                                 [NUL * 5,
-                                  NUL * 5,
-                                  NUL * 5])
+                                 [empty() * 5,
+                                  empty() * 5,
+                                  empty() * 5])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="DECSED not implemented")
@@ -176,11 +176,11 @@ class DECSEDTests(object):
 
     esccmd.DECSED()
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 5),
-                                 ["a" + NUL * 2,
-                                  NUL * 3,
+                                 ["a" + empty() * 2,
+                                  empty() * 3,
                                   "bcd",
-                                  NUL * 3,
-                                  "e" + NUL * 2])
+                                  empty() * 3,
+                                  "e" + empty() * 2])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="DECSED not implemented")
@@ -197,11 +197,11 @@ class DECSEDTests(object):
 
     esccmd.DECSED()
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 5),
-                                 ["a" + NUL * 2,
-                                  NUL * 3,
+                                 ["a" + empty() * 2,
+                                  empty() * 3,
                                   "bcd",
-                                  NUL * 3,
-                                  "e" + NUL * 2])
+                                  empty() * 3,
+                                  "e" + empty() * 2])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="DECSED not implemented")
@@ -220,11 +220,11 @@ class DECSEDTests(object):
 
     # X should be erased, other characters not.
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 5),
-                                 ["a" + NUL * 2,
-                                  NUL * 3,
+                                 ["a" + empty() * 2,
+                                  empty() * 3,
                                   "bcd",
-                                  NUL * 3,
-                                  "e" + NUL * 2])
+                                  empty() * 3,
+                                  "e" + empty() * 2])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="DECSED not implemented")
@@ -241,11 +241,11 @@ class DECSEDTests(object):
     esccmd.CUP(Point(2, 3))
     esccmd.DECSED(1)
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 5),
-                                 ["a" + NUL * 2,
-                                  NUL * 3,
+                                 ["a" + empty() * 2,
+                                  empty() * 3,
                                   "bcd",
-                                  NUL * 3,
-                                  "e" + NUL * 2])
+                                  empty() * 3,
+                                  "e" + empty() * 2])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="DECSED not implemented")
@@ -262,11 +262,11 @@ class DECSEDTests(object):
     # Erase the screen
     esccmd.DECSED(2)
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 5),
-                                 ["a" + NUL * 2,
-                                  NUL * 3,
+                                 ["a" + empty() * 2,
+                                  empty() * 3,
                                   "bcd",
-                                  NUL * 3,
-                                  "e" + NUL * 2])
+                                  empty() * 3,
+                                  "e" + empty() * 2])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="DECSED not implemented", noop=True)
@@ -284,11 +284,11 @@ class DECSEDTests(object):
 
     esccmd.DECSED(3)
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 5),
-                                 ["aX" + NUL,
-                                  NUL * 3,
+                                 ["aX" + empty(),
+                                  empty() * 3,
                                   "bcd",
-                                  NUL * 3,
-                                  "e" + NUL * 2])
+                                  empty() * 3,
+                                  "e" + empty() * 2])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="DECSED not implemented")

--- a/esctest/tests/decsel.py
+++ b/esctest/tests/decsel.py
@@ -1,4 +1,4 @@
-from esc import NUL, blank
+from esc import empty, blank
 import esccmd
 import escio
 from esctypes import Point, Rect
@@ -20,7 +20,7 @@ class DECSELTests(object):
     self.prepare()
     esccmd.DECSEL()
     AssertScreenCharsInRectEqual(Rect(1, 1, 10, 1),
-                                 ["abcd" + 6 * NUL])
+                                 ["abcd" + 6 * empty()])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="Not implemented")
@@ -29,7 +29,7 @@ class DECSELTests(object):
     self.prepare()
     esccmd.DECSEL(0)
     AssertScreenCharsInRectEqual(Rect(1, 1, 10, 1),
-                                 ["abcd" + 6 * NUL])
+                                 ["abcd" + 6 * empty()])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="Not implemented")
@@ -47,7 +47,7 @@ class DECSELTests(object):
     self.prepare()
     esccmd.DECSEL(2)
     AssertScreenCharsInRectEqual(Rect(1, 1, 10, 1),
-                                 [10 * NUL])
+                                 [10 * empty()])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="Not implemented")
@@ -60,7 +60,7 @@ class DECSELTests(object):
     esccmd.DECSEL(2)
     esccmd.DECRESET(esccmd.DECLRMM)
     AssertScreenCharsInRectEqual(Rect(1, 1, 10, 1),
-                                 [10 * NUL])
+                                 [10 * empty()])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="Not implemented")
@@ -77,7 +77,7 @@ class DECSELTests(object):
 
     esccmd.DECSEL()
     AssertScreenCharsInRectEqual(Rect(1, 1, 10, 1),
-                                 ["abcdefghi" + NUL])
+                                 ["abcdefghi" + empty()])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="Not implemented")
@@ -95,7 +95,7 @@ class DECSELTests(object):
     esccmd.DECSEL(0)
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 10, 1),
-                                 ["abcdefghi" + NUL])
+                                 ["abcdefghi" + empty()])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="Not implemented")

--- a/esctest/tests/decset.py
+++ b/esctest/tests/decset.py
@@ -1,4 +1,4 @@
-from esc import TAB, NUL, CR, LF, BS
+from esc import TAB, empty, CR, LF, BS
 from esctypes import Point, Rect
 from escutil import AssertEQ, AssertScreenCharsInRectEqual, GetCursorPosition, GetScreenSize, knownBug, optionRequired, vtLevel
 import escargs
@@ -94,7 +94,7 @@ class DECSETTests(object):
     esccmd.DECSTBM()
     esccmd.DECRESET(esccmd.DECLRMM)
     AssertScreenCharsInRectEqual(Rect(1, 2, 5, 3), ["Hello", "World"])
-    AssertScreenCharsInRectEqual(Rect(5, 5, 5, 5), [NUL])
+    AssertScreenCharsInRectEqual(Rect(5, 5, 5, 5), [empty()])
 
   @vtLevel(4)
   def test_DECSET_DECOM(self):
@@ -196,7 +196,7 @@ class DECSETTests(object):
     esccmd.DECSET(esccmd.DECAWM)
     escio.Write("abcdef")
 
-    AssertScreenCharsInRectEqual(Rect(5, 8, 9, 9), [NUL * 3 + "ab", "cdef" + NUL])
+    AssertScreenCharsInRectEqual(Rect(5, 8, 9, 9), [empty() * 3 + "ab", "cdef" + empty()])
 
   @vtLevel(4)
   def test_DECSET_DECAWM_OffRespectsLeftRightMargin(self):
@@ -209,7 +209,7 @@ class DECSETTests(object):
     escio.Write("abcdef")
 
     AssertEQ(GetCursorPosition().x(), 9)
-    AssertScreenCharsInRectEqual(Rect(5, 8, 9, 9), [NUL * 5, NUL * 3 + "af"])
+    AssertScreenCharsInRectEqual(Rect(5, 8, 9, 9), [empty() * 5, empty() * 3 + "af"])
 
   def test_DECSET_Allow80To132(self):
     """DECCOLM only has an effect if Allow80To132 is on."""
@@ -391,7 +391,7 @@ class DECSETTests(object):
     escio.Write("def" + CR +LF + "def")
 
     # Make sure abc is gone
-    AssertScreenCharsInRectEqual(Rect(1, 1, 3, 3), [NUL * 3, "def", "def"])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 3, 3), [empty() * 3, "def", "def"])
 
     # Switch to main. Cursor should not move.
     before = GetCursorPosition()
@@ -405,7 +405,7 @@ class DECSETTests(object):
       AssertEQ(before.y(), after.y())
 
     # def should be gone, abc should be back.
-    AssertScreenCharsInRectEqual(Rect(1, 1, 3, 3), ["abc", "abc", NUL * 3])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 3, 3), ["abc", "abc", empty() * 3])
 
     # Switch to alt
     before = GetCursorPosition()
@@ -417,9 +417,9 @@ class DECSETTests(object):
       AssertEQ(before.y(), after.y())
 
     if altGetsClearedBeforeToMain:
-      AssertScreenCharsInRectEqual(Rect(1, 1, 3, 3), [NUL * 3, NUL * 3, NUL * 3])
+      AssertScreenCharsInRectEqual(Rect(1, 1, 3, 3), [empty() * 3, empty() * 3, empty() * 3])
     else:
-      AssertScreenCharsInRectEqual(Rect(1, 1, 3, 3), [NUL * 3, "def", "def"])
+      AssertScreenCharsInRectEqual(Rect(1, 1, 3, 3), [empty() * 3, "def", "def"])
 
   @knownBug(terminal="iTerm2", reason="DECSET 1047 (OPT_ALTBUF) not implemented.")
   def test_DECSET_OPT_ALTBUF(self):
@@ -452,7 +452,7 @@ class DECSETTests(object):
     escio.Write("abcdefgh")
     esccmd.DECRESET(esccmd.DECLRMM)
 
-    AssertScreenCharsInRectEqual(Rect(1, 1, 4, 3), ["abcd", NUL + "efg", NUL + "h" + NUL * 2])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 4, 3), ["abcd", empty() + "efg", empty() + "h" + empty() * 2])
 
     # Turn off margins.
     esccmd.CUP(Point(1, 1))
@@ -512,7 +512,7 @@ class DECSETTests(object):
     esccmd.CUP(Point(1, 1))
     escio.Write("3")
     esccmd.DECSET(esccmd.DECCOLM)
-    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 1), [NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 1), [empty()])
 
     # 4: Reset DECNCSM, Reset column mode.
     esccmd.DECSET(esccmd.DECCOLM)
@@ -520,7 +520,7 @@ class DECSETTests(object):
     esccmd.CUP(Point(1, 1))
     escio.Write("4")
     esccmd.DECRESET(esccmd.DECCOLM)
-    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 1), [NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 1), [empty()])
 
   @knownBug(terminal="iTerm2", reason="Save/restore cursor not implemented")
   def test_DECSET_SaveRestoreCursor(self):

--- a/esctest/tests/decstbm.py
+++ b/esctest/tests/decstbm.py
@@ -1,4 +1,4 @@
-from esc import CR, LF, NUL
+from esc import CR, LF, empty
 import esccmd
 import escio
 from escutil import AssertEQ, GetCursorPosition, GetScreenSize, AssertScreenCharsInRectEqual, vtLevel
@@ -16,7 +16,7 @@ class DECSTBMTests(object):
     escio.Write("2")
     AssertScreenCharsInRectEqual(Rect(1, 2, 1, 3), ["1", "2"])
     escio.Write(CR + LF)
-    AssertScreenCharsInRectEqual(Rect(1, 2, 1, 3), ["2", NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 2, 1, 3), ["2", empty()])
     AssertEQ(GetCursorPosition().y(), 3)
 
   @vtLevel(4)
@@ -56,7 +56,7 @@ class DECSTBMTests(object):
       AssertScreenCharsInRectEqual(Rect(1, y, 4, y), ["%04d" % (i + 1)])
 
     y = size.height()
-    AssertScreenCharsInRectEqual(Rect(1, y, 4, y), [NUL * 4])
+    AssertScreenCharsInRectEqual(Rect(1, y, 4, y), [empty() * 4])
 
   @vtLevel(4)
   def test_DECSTBM_DefaultRestores(self):
@@ -104,7 +104,7 @@ class DECSTBMTests(object):
     escio.Write(CR + LF)
 
     # Verify that line 2 scrolled up to line 1.
-    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 2), ["x", NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 2), ["x", empty()])
 
     # Verify the cursor is at the last line on the page.
     AssertEQ(GetCursorPosition().y(), size.height())
@@ -136,7 +136,7 @@ class DECSTBMTests(object):
     escio.Write(CR + LF)
 
     # Verify that line 3 scrolled up to line 2.
-    AssertScreenCharsInRectEqual(Rect(1, 2, 1, 3), ["x", NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 2, 1, 3), ["x", empty()])
 
     # Verify the cursor is at the last line on the page.
     AssertEQ(GetCursorPosition().y(), size.height())

--- a/esctest/tests/decstr.py
+++ b/esctest/tests/decstr.py
@@ -1,4 +1,4 @@
-from esc import BS, CR, LF, NUL
+from esc import BS, CR, LF, empty
 import esccmd
 import escio
 from escutil import AssertEQ, AssertScreenCharsInRectEqual, GetCursorPosition, GetScreenSize, intentionalDeviationFromSpec, knownBug, vtLevel
@@ -80,10 +80,10 @@ class DECSTRTests(object):
     # Make sure the X was at 1, 1, implying origin mode was off.
     esccmd.DECSTBM()
     esccmd.DECRESET(esccmd.DECLRMM)
-    AssertScreenCharsInRectEqual(Rect(1, 1, 3, 4), ["X" + NUL * 2,
-                                                    NUL * 3,
-                                                    NUL * 3,
-                                                    NUL * 3])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 3, 4), ["X" + empty() * 2,
+                                                    empty() * 3,
+                                                    empty() * 3,
+                                                    empty() * 3])
 
   @intentionalDeviationFromSpec(terminal="iTerm2",
                                 reason="For compatibility purposes, iTerm2 mimics xterm's behavior of turning on DECAWM by default.")
@@ -142,7 +142,7 @@ class DECSTRTests(object):
     esccmd.CUP(Point(1, 1))
     escio.Write("X")
     esccmd.DECSED(2)
-    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 1), [NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 1), [empty()])
 
   @vtLevel(4)
   def test_DECSTR_DECSASD(self):

--- a/esctest/tests/dl.py
+++ b/esctest/tests/dl.py
@@ -1,4 +1,4 @@
-from esc import NUL
+from esc import empty
 import esccmd
 import escio
 from esctypes import Point, Rect
@@ -56,7 +56,7 @@ class DLTests(object):
       y += 1
 
     # The last line should be blank
-    expected_lines.append(NUL * 4)
+    expected_lines.append(empty() * 4)
     AssertScreenCharsInRectEqual(Rect(1, 1, 4, height), expected_lines)
 
   @vtLevel(4)
@@ -78,8 +78,8 @@ class DLTests(object):
       y += 1
 
     # The last two lines should be blank
-    expected_lines.append(NUL * 4)
-    expected_lines.append(NUL * 4)
+    expected_lines.append(empty() * 4)
+    expected_lines.append(empty() * 4)
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 4, height), expected_lines)
 
@@ -97,7 +97,7 @@ class DLTests(object):
     y = 1
     expected_lines = ["0001"]
     for i in xrange(height - 1):
-      expected_lines.append(NUL * 4)
+      expected_lines.append(empty() * 4)
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 4, height), expected_lines)
 
@@ -114,7 +114,7 @@ class DLTests(object):
     expected_lines = ["abcde",
                       "klmno",
                       "pqrst",
-                      NUL * 5,
+                      empty() * 5,
                       "uvwxy"]
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5), expected_lines)
 
@@ -150,7 +150,7 @@ class DLTests(object):
                       "flmnj",
                       "kqrso",
                       "pvwxt",
-                      "u" + NUL * 3 + "y"]
+                      "u" + empty() * 3 + "y"]
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5), expected_lines)
 
@@ -187,7 +187,7 @@ class DLTests(object):
     expected_lines = ["abcde",
                       "flmnj",
                       "kqrso",
-                      "p" + NUL * 3 + "t",
+                      "p" + empty() * 3 + "t",
                       "uvwxy"]
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5), expected_lines)
@@ -205,9 +205,9 @@ class DLTests(object):
     esccmd.DECSTBM()
 
     expected_lines = ["abcde",
-                      "f" + NUL * 3 + "j",
-                      "k" + NUL * 3 + "o",
-                      "p" + NUL * 3 + "t",
+                      "f" + empty() * 3 + "j",
+                      "k" + empty() * 3 + "o",
+                      "p" + empty() * 3 + "t",
                       "uvwxy"]
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5), expected_lines)

--- a/esctest/tests/ed.py
+++ b/esctest/tests/ed.py
@@ -1,4 +1,4 @@
-from esc import NUL, blank
+from esc import empty, blank
 import esccmd
 import escio
 from esctypes import Point, Rect
@@ -47,11 +47,11 @@ class EDTests(object):
     self.prepare()
     esccmd.ED()
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 5),
-                                 ["a" + NUL * 2,
-                                  NUL * 3,
-                                  "b" + NUL * 2,
-                                  NUL * 3,
-                                  NUL * 3])
+                                 ["a" + empty() * 2,
+                                  empty() * 3,
+                                  "b" + empty() * 2,
+                                  empty() * 3,
+                                  empty() * 3])
 
   @vtLevel(4)
   def test_ED_0(self):
@@ -59,11 +59,11 @@ class EDTests(object):
     self.prepare()
     esccmd.ED(0)
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 5),
-                                 ["a" + NUL * 2,
-                                  NUL * 3,
-                                  "b" + NUL * 2,
-                                  NUL * 3,
-                                  NUL * 3])
+                                 ["a" + empty() * 2,
+                                  empty() * 3,
+                                  "b" + empty() * 2,
+                                  empty() * 3,
+                                  empty() * 3])
 
   @vtLevel(4)
   def test_ED_1(self):
@@ -71,11 +71,11 @@ class EDTests(object):
     self.prepare()
     esccmd.ED(1)
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 5),
-                                 [NUL * 3,
-                                  NUL * 3,
+                                 [empty() * 3,
+                                  empty() * 3,
                                   blank() * 2 + "d",
-                                  NUL * 3,
-                                  "e" + NUL * 2])
+                                  empty() * 3,
+                                  "e" + empty() * 2])
 
   @vtLevel(4)
   def test_ED_2(self):
@@ -83,11 +83,11 @@ class EDTests(object):
     self.prepare()
     esccmd.ED(2)
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 5),
-                                 [NUL * 3,
-                                  NUL * 3,
-                                  NUL * 3,
-                                  NUL * 3,
-                                  NUL * 3])
+                                 [empty() * 3,
+                                  empty() * 3,
+                                  empty() * 3,
+                                  empty() * 3,
+                                  empty() * 3])
 
   @vtLevel(4)
   def test_ED_3(self):
@@ -97,11 +97,11 @@ class EDTests(object):
     self.prepare()
     esccmd.ED(3)
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 5),
-                                 ["a" + NUL * 2,
-                                  NUL * 3,
+                                 ["a" + empty() * 2,
+                                  empty() * 3,
                                   "bcd",
-                                  NUL * 3,
-                                  "e" + NUL * 2])
+                                  empty() * 3,
+                                  "e" + empty() * 2])
 
   @vtLevel(4)
   def test_ED_0_WithScrollRegion(self):
@@ -116,8 +116,8 @@ class EDTests(object):
     esccmd.DECSTBM()
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 3),
                                  ["abcde",
-                                  "fg" + NUL * 3,
-                                  NUL * 5])
+                                  "fg" + empty() * 3,
+                                  empty() * 5])
 
   @vtLevel(4)
   def test_ED_1_WithScrollRegion(self):
@@ -131,7 +131,7 @@ class EDTests(object):
     esccmd.DECRESET(esccmd.DECLRMM)
     esccmd.DECSTBM()
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 3),
-                                 [NUL * 5,
+                                 [empty() * 5,
                                   blank() * 3 + "ij",
                                   "klmno"])
 
@@ -147,9 +147,9 @@ class EDTests(object):
     esccmd.DECRESET(esccmd.DECLRMM)
     esccmd.DECSTBM()
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 3),
-                                 [NUL * 5,
-                                  NUL * 5,
-                                  NUL * 5])
+                                 [empty() * 5,
+                                  empty() * 5,
+                                  empty() * 5])
 
   @vtLevel(4)
   def test_ED_doesNotRespectDECProtection(self):
@@ -162,7 +162,7 @@ class EDTests(object):
     esccmd.CUP(Point(1, 1))
     esccmd.ED(0)
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 1),
-                                 [NUL * 3])
+                                 [empty() * 3])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2",

--- a/esctest/tests/el.py
+++ b/esctest/tests/el.py
@@ -1,4 +1,4 @@
-from esc import NUL, blank
+from esc import empty, blank
 import esccmd
 import escio
 from esctypes import Point, Rect
@@ -18,7 +18,7 @@ class ELTests(object):
     self.prepare()
     esccmd.EL()
     AssertScreenCharsInRectEqual(Rect(1, 1, 10, 1),
-                                 ["abcd" + 6 * NUL])
+                                 ["abcd" + 6 * empty()])
 
   @vtLevel(4)
   def test_EL_0(self):
@@ -26,7 +26,7 @@ class ELTests(object):
     self.prepare()
     esccmd.EL(0)
     AssertScreenCharsInRectEqual(Rect(1, 1, 10, 1),
-                                 ["abcd" + 6 * NUL])
+                                 ["abcd" + 6 * empty()])
 
   @vtLevel(4)
   def test_EL_1(self):
@@ -42,7 +42,7 @@ class ELTests(object):
     self.prepare()
     esccmd.EL(2)
     AssertScreenCharsInRectEqual(Rect(1, 1, 10, 1),
-                                 [10 * NUL])
+                                 [10 * empty()])
 
   @vtLevel(4)
   def test_EL_IgnoresScrollRegion(self):
@@ -54,7 +54,7 @@ class ELTests(object):
     esccmd.EL(2)
     esccmd.DECRESET(esccmd.DECLRMM)
     AssertScreenCharsInRectEqual(Rect(1, 1, 10, 1),
-                                 [10 * NUL])
+                                 [10 * empty()])
 
   @vtLevel(4)
   def test_EL_doesNotRespectDECProtection(self):
@@ -67,7 +67,7 @@ class ELTests(object):
     esccmd.CUP(Point(1, 1))
     esccmd.EL(2)
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 1),
-                                 [NUL * 3])
+                                 [empty() * 3])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2",

--- a/esctest/tests/ff.py
+++ b/esctest/tests/ff.py
@@ -1,4 +1,4 @@
-from esc import FF, NUL
+from esc import FF, empty
 import esccmd
 import escio
 from escutil import AssertEQ, AssertScreenCharsInRectEqual, GetCursorPosition, GetScreenSize, vtLevel
@@ -32,12 +32,12 @@ class FFTests(object):
     # Move down, ensure no scroll yet.
     escio.Write(FF)
     AssertEQ(GetCursorPosition().y(), height)
-    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), [NUL, "a", "b"])
+    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), [empty(), "a", "b"])
 
     # Move down, ensure scroll.
     escio.Write(FF)
     AssertEQ(GetCursorPosition().y(), height)
-    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), ["a", "b", NUL])
+    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), ["a", "b", empty()])
 
   @vtLevel(4)
   def test_FF_ScrollsInTopBottomRegionStartingAbove(self):
@@ -51,7 +51,7 @@ class FFTests(object):
     escio.Write(FF)
     escio.Write(FF)
     AssertEQ(GetCursorPosition(), Point(2, 5))
-    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", NUL])
+    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", empty()])
 
   @vtLevel(4)
   def test_FF_ScrollsInTopBottomRegionStartingWithin(self):
@@ -64,7 +64,7 @@ class FFTests(object):
     escio.Write(FF)
     escio.Write(FF)
     AssertEQ(GetCursorPosition(), Point(2, 5))
-    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", NUL])
+    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", empty()])
 
   @vtLevel(4)
   def test_FF_MovesDoesNotScrollOutsideLeftRight(self):

--- a/esctest/tests/hpr.py
+++ b/esctest/tests/hpr.py
@@ -1,4 +1,4 @@
-from esc import NUL
+from esc import empty
 import esccmd
 import escio
 from escutil import AssertEQ, AssertScreenCharsInRectEqual, GetCursorPosition, GetScreenSize, knownBug, vtLevel
@@ -67,4 +67,4 @@ class HPRTests(object):
     esccmd.DECSTBM()
 
     # See what happened
-    AssertScreenCharsInRectEqual(Rect(5, 7, 9, 7), [NUL + "X" + NUL * 2 + "Y"])
+    AssertScreenCharsInRectEqual(Rect(5, 7, 9, 7), [empty() + "X" + empty() * 2 + "Y"])

--- a/esctest/tests/ich.py
+++ b/esctest/tests/ich.py
@@ -1,4 +1,4 @@
-from esc import NUL, blank
+from esc import empty, blank
 import esccmd
 import escio
 from escutil import AssertEQ, GetCursorPosition, GetScreenSize, AssertScreenCharsInRectEqual, vtLevel
@@ -67,7 +67,7 @@ class ICHTests(object):
     AssertScreenCharsInRectEqual(Rect(startX, 1, width, 1),
                                  ["a" + blank() + "bcdef"])
     # Ensure there is no wrap-around.
-    AssertScreenCharsInRectEqual(Rect(1, 2, 1, 2), [NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 2, 1, 2), [empty()])
 
   @vtLevel(4)
   def test_ICH_ScrollEntirelyOffRightEdge(self):
@@ -83,7 +83,7 @@ class ICHTests(object):
     AssertScreenCharsInRectEqual(Rect(1, 1, width, 1),
                                  [expectedLine])
     # Ensure there is no wrap-around.
-    AssertScreenCharsInRectEqual(Rect(1, 2, 1, 2), [NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 2, 1, 2), [empty()])
 
   @vtLevel(4)
   def test_ICH_ScrollOffRightMarginInScrollRegion(self):

--- a/esctest/tests/il.py
+++ b/esctest/tests/il.py
@@ -1,4 +1,4 @@
-from esc import NUL
+from esc import empty
 import esccmd
 import escio
 from esctypes import Point, Rect
@@ -48,7 +48,7 @@ class ILTests(object):
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 4),
                                  ["abcde",
                                   "fghij",
-                                  NUL * 5,
+                                  empty() * 5,
                                   "klmno"])
 
   @vtLevel(4)
@@ -59,8 +59,8 @@ class ILTests(object):
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5),
                                  ["abcde",
                                   "fghij",
-                                  NUL * 5,
-                                  NUL * 5,
+                                  empty() * 5,
+                                  empty() * 5,
                                   "klmno"])
 
   @vtLevel(4)
@@ -77,7 +77,7 @@ class ILTests(object):
     for i in xrange(height):
       y = i + 1
       if y == 2:
-        AssertScreenCharsInRectEqual(Rect(1, y, 4, y), [NUL * 4])
+        AssertScreenCharsInRectEqual(Rect(1, y, 4, y), [empty() * 4])
       else:
         AssertScreenCharsInRectEqual(Rect(1, y, 4, y), ["%04d" % expected])
         expected += 1
@@ -95,7 +95,7 @@ class ILTests(object):
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5),
                                  ["abcde",
-                                  "f" + NUL * 3 + "j",
+                                  "f" + empty() * 3 + "j",
                                   "kGHIo",
                                   "pLMNt",
                                   "uvwxy"])
@@ -111,9 +111,9 @@ class ILTests(object):
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5),
                                  ["abcde",
-                                  "f" + NUL * 3 + "j",
-                                  "k" + NUL * 3 + "o",
-                                  "p" + NUL * 3 + "t",
+                                  "f" + empty() * 3 + "j",
+                                  "k" + empty() * 3 + "o",
+                                  "p" + empty() * 3 + "t",
                                   "uvwxy"])
 
   @vtLevel(4)

--- a/esctest/tests/ind.py
+++ b/esctest/tests/ind.py
@@ -1,4 +1,4 @@
-from esc import NUL, S7C1T, S8C1T
+from esc import empty, S7C1T, S8C1T
 import escargs
 import esccmd
 import escio
@@ -31,12 +31,12 @@ class INDTests(object):
     # Move down, ensure no scroll yet.
     esccmd.IND()
     AssertEQ(GetCursorPosition().y(), height)
-    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), [NUL, "a", "b"])
+    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), [empty(), "a", "b"])
 
     # Move down, ensure scroll.
     esccmd.IND()
     AssertEQ(GetCursorPosition().y(), height)
-    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), ["a", "b", NUL])
+    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), ["a", "b", empty()])
 
   @vtLevel(4)
   def test_IND_ScrollsInTopBottomRegionStartingAbove(self):
@@ -50,7 +50,7 @@ class INDTests(object):
     esccmd.IND()  # To 5
     esccmd.IND()  # Stay at 5 and scroll x up one line
     AssertEQ(GetCursorPosition(), Point(2, 5))
-    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", NUL])
+    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", empty()])
 
   @vtLevel(4)
   def test_IND_ScrollsInTopBottomRegionStartingWithin(self):
@@ -63,7 +63,7 @@ class INDTests(object):
     esccmd.IND()  # To 5
     esccmd.IND()  # Stay at 5 and scroll x up one line
     AssertEQ(GetCursorPosition(), Point(2, 5))
-    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", NUL])
+    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", empty()])
 
   @vtLevel(4)
   def test_IND_MovesDoesNotScrollOutsideLeftRight(self):

--- a/esctest/tests/lf.py
+++ b/esctest/tests/lf.py
@@ -1,4 +1,4 @@
-from esc import LF, NUL
+from esc import LF, empty
 import esccmd
 import escio
 from escutil import AssertEQ, AssertScreenCharsInRectEqual, GetCursorPosition, GetScreenSize, vtLevel
@@ -32,12 +32,12 @@ class LFTests(object):
     # Move down, ensure no scroll yet.
     escio.Write(LF)
     AssertEQ(GetCursorPosition().y(), height)
-    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), [NUL, "a", "b"])
+    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), [empty(), "a", "b"])
 
     # Move down, ensure scroll.
     escio.Write(LF)
     AssertEQ(GetCursorPosition().y(), height)
-    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), ["a", "b", NUL])
+    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), ["a", "b", empty()])
 
   @vtLevel(4)
   def test_LF_ScrollsInTopBottomRegionStartingAbove(self):
@@ -51,7 +51,7 @@ class LFTests(object):
     escio.Write(LF)
     escio.Write(LF)
     AssertEQ(GetCursorPosition(), Point(2, 5))
-    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", NUL])
+    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", empty()])
 
   @vtLevel(4)
   def test_LF_ScrollsInTopBottomRegionStartingWithin(self):
@@ -64,7 +64,7 @@ class LFTests(object):
     escio.Write(LF)
     escio.Write(LF)
     AssertEQ(GetCursorPosition(), Point(2, 5))
-    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", NUL])
+    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", empty()])
 
   @vtLevel(4)
   def test_LF_MovesDoesNotScrollOutsideLeftRight(self):

--- a/esctest/tests/nel.py
+++ b/esctest/tests/nel.py
@@ -1,4 +1,4 @@
-from esc import NUL, S7C1T, S8C1T
+from esc import empty, S7C1T, S8C1T
 import escargs
 import esccmd
 import escio
@@ -31,12 +31,12 @@ class NELTests(object):
     # Move down, ensure no scroll yet.
     esccmd.NEL()
     AssertEQ(GetCursorPosition(), Point(1, height))
-    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), [NUL, "a", "b"])
+    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), [empty(), "a", "b"])
 
     # Move down, ensure scroll.
     esccmd.NEL()
     AssertEQ(GetCursorPosition(), Point(1, height))
-    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), ["a", "b", NUL])
+    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), ["a", "b", empty()])
 
   @vtLevel(4)
   def test_NEL_ScrollsInTopBottomRegionStartingAbove(self):
@@ -50,7 +50,7 @@ class NELTests(object):
     esccmd.NEL()  # To 5
     esccmd.NEL()  # Stay at 5 and scroll x up one line
     AssertEQ(GetCursorPosition(), Point(1, 5))
-    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", NUL])
+    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", empty()])
 
   @vtLevel(4)
   def test_NEL_ScrollsInTopBottomRegionStartingWithin(self):
@@ -63,7 +63,7 @@ class NELTests(object):
     esccmd.NEL()  # To 5
     esccmd.NEL()  # Stay at 5 and scroll x up one line
     AssertEQ(GetCursorPosition(), Point(1, 5))
-    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", NUL])
+    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", empty()])
 
   @vtLevel(4)
   def test_NEL_MovesDoesNotScrollOutsideLeftRight(self):

--- a/esctest/tests/pm.py
+++ b/esctest/tests/pm.py
@@ -1,4 +1,4 @@
-from esc import NUL, ST, S7C1T, S8C1T
+from esc import empty, ST, S7C1T, S8C1T
 import escargs
 import esccmd
 import escio
@@ -15,7 +15,7 @@ class PMTests(object):
     escio.Write("A")
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 1),
-                                 ["A" + NUL * 2])
+                                 ["A" + empty() * 2])
 
   @vtLevel(4)
   @optionRequired(terminal="xterm", option=escargs.DISABLE_WIDE_CHARS)
@@ -31,4 +31,4 @@ class PMTests(object):
     escio.use8BitControls = False
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 1),
-                                 ["A" + NUL * 2])
+                                 ["A" + empty() * 2])

--- a/esctest/tests/rep.py
+++ b/esctest/tests/rep.py
@@ -6,7 +6,7 @@ which limits editing and cursor movement using top/bottom and left/right
 margins.  Top/bottom margins are a VT100 feature; left/right margins were
 introduced with the VT420.
 """
-from esc import NUL
+from esc import empty
 import esccmd
 import escio
 from escutil import AssertScreenCharsInRectEqual, GetScreenSize, knownBug, vtLevel
@@ -18,14 +18,14 @@ class REPTests(object):
   def test_REP_DefaultParam(self):
     escio.Write("a")
     esccmd.REP()
-    AssertScreenCharsInRectEqual(Rect(1, 1, 3, 1), ["aa" + NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 3, 1), ["aa" + empty()])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="Not implemented")
   def test_REP_ExplicitParam(self):
     escio.Write("a")
     esccmd.REP(2)
-    AssertScreenCharsInRectEqual(Rect(1, 1, 4, 1), ["aaa" + NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 4, 1), ["aaa" + empty()])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="Not implemented")
@@ -38,8 +38,8 @@ class REPTests(object):
     esccmd.DECRESET(esccmd.DECLRMM)
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 2),
-                                 [NUL + "aaa" + NUL,
-                                  NUL + "a" + NUL * 3])
+                                 [empty() + "aaa" + empty(),
+                                  empty() + "a" + empty() * 3])
 
   @vtLevel(4)
   @knownBug(terminal="iTerm2", reason="Not implemented")
@@ -51,5 +51,5 @@ class REPTests(object):
     esccmd.REP(3)
 
     AssertScreenCharsInRectEqual(Rect(1, 3, width, 4),
-                                 [NUL * (width - 3) + "aaa",
-                                  "a" + NUL * (width - 1)])
+                                 [empty() * (width - 3) + "aaa",
+                                  "a" + empty() * (width - 1)])

--- a/esctest/tests/ri.py
+++ b/esctest/tests/ri.py
@@ -1,4 +1,4 @@
-from esc import NUL, S7C1T, S8C1T
+from esc import empty, S7C1T, S8C1T
 import escargs
 import esccmd
 import escio
@@ -29,12 +29,12 @@ class RITests(object):
     # Move up, ensure no scroll yet.
     esccmd.RI()
     AssertEQ(GetCursorPosition().y(), 1)
-    AssertScreenCharsInRectEqual(Rect(2, 1, 2, 3), ["a", "b", NUL])
+    AssertScreenCharsInRectEqual(Rect(2, 1, 2, 3), ["a", "b", empty()])
 
     # Move up, ensure scroll.
     esccmd.RI()
     AssertEQ(GetCursorPosition().y(), 1)
-    AssertScreenCharsInRectEqual(Rect(2, 1, 2, 3), [NUL, "a", "b"])
+    AssertScreenCharsInRectEqual(Rect(2, 1, 2, 3), [empty(), "a", "b"])
 
   @vtLevel(4)
   def test_RI_ScrollsInTopBottomRegionStartingBelow(self):
@@ -48,7 +48,7 @@ class RITests(object):
     esccmd.RI()  # To 4
     esccmd.RI()  # Stay at 4 and scroll x down one line
     AssertEQ(GetCursorPosition(), Point(2, 4))
-    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), [NUL, "x"])
+    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), [empty(), "x"])
 
   @vtLevel(4)
   def test_RI_ScrollsInTopBottomRegionStartingWithin(self):
@@ -61,7 +61,7 @@ class RITests(object):
     esccmd.RI()  # To 4
     esccmd.RI()  # Stay at 4 and scroll x down one line
     AssertEQ(GetCursorPosition(), Point(2, 4))
-    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), [NUL, "x"])
+    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), [empty(), "x"])
 
   @vtLevel(4)
   def test_RI_MovesDoesNotScrollOutsideLeftRight(self):

--- a/esctest/tests/ris.py
+++ b/esctest/tests/ris.py
@@ -1,4 +1,4 @@
-from esc import NUL, TAB
+from esc import empty, TAB
 import esccmd
 import escio
 from escutil import AssertEQ, AssertScreenCharsInRectEqual, GetCursorPosition, GetScreenSize, GetIconTitle, GetWindowTitle, knownBug, vtLevel
@@ -11,7 +11,7 @@ class RISTests(object):
 
     esccmd.RIS()
 
-    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 1), [NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 1), [empty()])
 
   def test_RIS_CursorToOrigin(self):
     esccmd.CUP(Point(5, 6))
@@ -58,7 +58,7 @@ class RISTests(object):
 
     esccmd.RIS()
 
-    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 1), [NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 1, 1), [empty()])
     esccmd.DECSET(esccmd.ALTBUF)
     AssertScreenCharsInRectEqual(Rect(1, 1, 1, 1), ["a"])
 

--- a/esctest/tests/save_restore_cursor.py
+++ b/esctest/tests/save_restore_cursor.py
@@ -23,6 +23,7 @@ import esc
 import esccmd
 import escargs
 import escio
+from esc import empty
 from escutil import AssertEQ, AssertScreenCharsInRectEqual, GetCursorPosition, GetScreenSize, Rect, knownBug, vtLevel
 from esctypes import Point
 
@@ -187,4 +188,4 @@ class SaveRestoreCursorTests(object):
     escio.Write("a")
     esccmd.CUP(Point(1, 1))
     escio.Write("b")
-    AssertScreenCharsInRectEqual(Rect(1, 1, 2, 1), ["b" + esc.NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 1, 2, 1), ["b" + empty()])

--- a/esctest/tests/sd.py
+++ b/esctest/tests/sd.py
@@ -1,4 +1,4 @@
-from esc import NUL
+from esc import empty
 import esccmd
 import escio
 from esctypes import Point, Rect
@@ -38,7 +38,7 @@ class SDTests(object):
     """SD with no parameter should scroll the screen contents down one line."""
     self.prepare()
     esccmd.SD()
-    expected_lines = [NUL * 5,
+    expected_lines = [empty() * 5,
                       "abcde",
                       "fghij",
                       "klmno",
@@ -50,8 +50,8 @@ class SDTests(object):
     """SD should scroll the screen down by the number of lines given in the parameter."""
     self.prepare()
     esccmd.SD(2)
-    expected_lines = [NUL * 5,
-                      NUL * 5,
+    expected_lines = [empty() * 5,
+                      empty() * 5,
                       "abcde",
                       "fghij",
                       "klmno"]
@@ -71,7 +71,7 @@ class SDTests(object):
       y = i + 1
       esccmd.CUP(Point(1, y))
       escio.Write("%04d" % y)
-      expected_lines.append(NUL * 4)
+      expected_lines.append(empty() * 4)
 
     # Scroll by |height|
     esccmd.SD(height)
@@ -90,8 +90,8 @@ class SDTests(object):
     esccmd.DECSTBM()
 
     expected_lines = ["abcde",
-                      NUL * 5,
-                      NUL * 5,
+                      empty() * 5,
+                      empty() * 5,
                       "fghij",
                       "uvwxy"]
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5), expected_lines)
@@ -107,8 +107,8 @@ class SDTests(object):
     esccmd.DECSTBM()
 
     expected_lines = ["abcde",
-                      NUL * 5,
-                      NUL * 5,
+                      empty() * 5,
+                      empty() * 5,
                       "fghij",
                       "uvwxy"]
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5), expected_lines)
@@ -124,8 +124,8 @@ class SDTests(object):
     esccmd.SD(2)
     esccmd.DECRESET(esccmd.DECLRMM)
 
-    expected_lines = ["a" + NUL * 3 + "e",
-                      "f" + NUL * 3 + "j",
+    expected_lines = ["a" + empty() * 3 + "e",
+                      "f" + empty() * 3 + "j",
                       "kbcdo",
                       "pghit",
                       "ulmny"]
@@ -143,13 +143,13 @@ class SDTests(object):
     esccmd.DECSTBM()
     esccmd.DECRESET(esccmd.DECLRMM)
 
-    expected_lines = ["a" + NUL * 3 + "e",
-                      "f" + NUL * 3 + "j",
+    expected_lines = ["a" + empty() * 3 + "e",
+                      "f" + empty() * 3 + "j",
                       "kbcdo",
                       "pghit",
                       "ulmny",
-                      NUL + "qrs" + NUL,
-                      NUL + "vwx" + NUL]
+                      empty() + "qrs" + empty(),
+                      empty() + "vwx" + empty()]
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 7), expected_lines)
 
   @vtLevel(4)
@@ -166,8 +166,8 @@ class SDTests(object):
     esccmd.DECRESET(esccmd.DECLRMM)
 
     expected_lines = ["abcde",
-                      "f" + NUL * 3 + "j",
-                      "k" + NUL * 3 + "o",
+                      "f" + empty() * 3 + "j",
+                      "k" + empty() * 3 + "o",
                       "pghit",
                       "uvwxy"]
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5), expected_lines)
@@ -185,8 +185,8 @@ class SDTests(object):
     esccmd.DECRESET(esccmd.DECLRMM)
 
     expected_lines = ["abcde",
-                      "f" + NUL * 3 + "j",
-                      "k" + NUL * 3 + "o",
-                      "p" + NUL * 3 + "t",
+                      "f" + empty() * 3 + "j",
+                      "k" + empty() * 3 + "o",
+                      "p" + empty() * 3 + "t",
                       "uvwxy"]
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5), expected_lines)

--- a/esctest/tests/sm.py
+++ b/esctest/tests/sm.py
@@ -1,4 +1,4 @@
-from esc import NUL, LF, VT, FF
+from esc import empty, LF, VT, FF
 import esccmd
 import escio
 from escutil import AssertEQ, AssertScreenCharsInRectEqual, GetCursorPosition, GetScreenSize, knownBug, vtLevel
@@ -24,9 +24,9 @@ class SMTests(object):
     escio.Write("b")
     esccmd.CUP(Point(1, 1))
     esccmd.SM(esccmd.IRM)
-    AssertScreenCharsInRectEqual(Rect(1, 2, 1, 2), [NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 2, 1, 2), [empty()])
     escio.Write("X")
-    AssertScreenCharsInRectEqual(Rect(1, 2, 1, 2), [NUL])
+    AssertScreenCharsInRectEqual(Rect(1, 2, 1, 2), [empty()])
     esccmd.CUP(Point(size.width(), 1))
     escio.Write("YZ")
     AssertScreenCharsInRectEqual(Rect(1, 2, 1, 2), ["Z"])
@@ -46,7 +46,7 @@ class SMTests(object):
     escio.Write("X")
     esccmd.DECRESET(esccmd.DECLRMM)
 
-    AssertScreenCharsInRectEqual(Rect(5, 1, 11, 1), ["abXcde" + NUL])
+    AssertScreenCharsInRectEqual(Rect(5, 1, 11, 1), ["abXcde" + empty()])
 
   def doLinefeedModeTest(self, code):
     esccmd.RM(esccmd.LNM)

--- a/esctest/tests/sos.py
+++ b/esctest/tests/sos.py
@@ -1,4 +1,4 @@
-from esc import NUL, ST, S7C1T, S8C1T
+from esc import empty, ST, S7C1T, S8C1T
 import escargs
 import esccmd
 import escio
@@ -15,7 +15,7 @@ class SOSTests(object):
     escio.Write("A")
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 1),
-                                 ["A" + NUL * 2])
+                                 ["A" + empty() * 2])
 
   @vtLevel(4)
   @optionRequired(terminal="xterm", option=escargs.DISABLE_WIDE_CHARS)
@@ -31,4 +31,4 @@ class SOSTests(object):
     escio.use8BitControls = False
 
     AssertScreenCharsInRectEqual(Rect(1, 1, 3, 1),
-                                 ["A" + NUL * 2])
+                                 ["A" + empty() * 2])

--- a/esctest/tests/su.py
+++ b/esctest/tests/su.py
@@ -1,4 +1,4 @@
-from esc import NUL
+from esc import empty
 import esccmd
 import escio
 from esctypes import Point, Rect
@@ -35,7 +35,7 @@ class SUTests(object):
                       "klmno",
                       "pqrst",
                       "uvwxy",
-                      NUL * 5]
+                      empty() * 5]
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5), expected_lines)
 
   @vtLevel(4)
@@ -46,8 +46,8 @@ class SUTests(object):
     expected_lines = ["klmno",
                       "pqrst",
                       "uvwxy",
-                      NUL * 5,
-                      NUL * 5]
+                      empty() * 5,
+                      empty() * 5]
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5), expected_lines)
 
   @vtLevel(4)
@@ -60,7 +60,7 @@ class SUTests(object):
       y = i + 1
       esccmd.CUP(Point(1, y))
       escio.Write("%04d" % y)
-      expected_lines.append(NUL * 4)
+      expected_lines.append(empty() * 4)
 
     # Scroll by |height|
     esccmd.SU(height)
@@ -80,8 +80,8 @@ class SUTests(object):
 
     expected_lines = ["abcde",
                       "pqrst",
-                      NUL * 5,
-                      NUL * 5,
+                      empty() * 5,
+                      empty() * 5,
                       "uvwxy"]
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5), expected_lines)
 
@@ -97,8 +97,8 @@ class SUTests(object):
 
     expected_lines = ["abcde",
                       "pqrst",
-                      NUL * 5,
-                      NUL * 5,
+                      empty() * 5,
+                      empty() * 5,
                       "uvwxy"]
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5), expected_lines)
 
@@ -116,8 +116,8 @@ class SUTests(object):
     expected_lines = ["almne",
                       "fqrsj",
                       "kvwxo",
-                      "p" + NUL * 3 + "t",
-                      "u" + NUL * 3 + "y"]
+                      "p" + empty() * 3 + "t",
+                      "u" + empty() * 3 + "y"]
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5), expected_lines)
 
   @vtLevel(4)
@@ -135,8 +135,8 @@ class SUTests(object):
     expected_lines = ["almne",
                       "fqrsj",
                       "kvwxo",
-                      "p" + NUL * 3 + "t",
-                      "u" + NUL * 3 + "y"]
+                      "p" + empty() * 3 + "t",
+                      "u" + empty() * 3 + "y"]
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5), expected_lines)
 
   @vtLevel(4)
@@ -154,8 +154,8 @@ class SUTests(object):
 
     expected_lines = ["abcde",
                       "fqrsj",
-                      "k" + NUL * 3 + "o",
-                      "p" + NUL * 3 + "t",
+                      "k" + empty() * 3 + "o",
+                      "p" + empty() * 3 + "t",
                       "uvwxy"]
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5), expected_lines)
 
@@ -172,8 +172,8 @@ class SUTests(object):
     esccmd.DECRESET(esccmd.DECLRMM)
 
     expected_lines = ["abcde",
-                      "f" + NUL * 3 + "j",
-                      "k" + NUL * 3 + "o",
-                      "p" + NUL * 3 + "t",
+                      "f" + empty() * 3 + "j",
+                      "k" + empty() * 3 + "o",
+                      "p" + empty() * 3 + "t",
                       "uvwxy"]
     AssertScreenCharsInRectEqual(Rect(1, 1, 5, 5), expected_lines)

--- a/esctest/tests/vpr.py
+++ b/esctest/tests/vpr.py
@@ -1,4 +1,4 @@
-from esc import NUL
+from esc import empty
 import esccmd
 import escio
 from escutil import AssertEQ, AssertScreenCharsInRectEqual, GetCursorPosition, GetScreenSize, vtLevel
@@ -63,7 +63,7 @@ class VPRTests(object):
     esccmd.DECSTBM()
 
     # See what happened
-    AssertScreenCharsInRectEqual(Rect(6, 7, 7, 9), ['X' + NUL,
-                                                    NUL * 2,
-                                                    NUL + 'Y'])
+    AssertScreenCharsInRectEqual(Rect(6, 7, 7, 9), ['X' + empty(),
+                                                    empty() * 2,
+                                                    empty() + 'Y'])
 

--- a/esctest/tests/vt.py
+++ b/esctest/tests/vt.py
@@ -1,4 +1,4 @@
-from esc import VT, NUL
+from esc import VT, empty
 import esccmd
 import escio
 from escutil import AssertEQ, AssertScreenCharsInRectEqual, GetCursorPosition, GetScreenSize, vtLevel
@@ -32,12 +32,12 @@ class VTTests(object):
     # Move down, ensure no scroll yet.
     escio.Write(VT)
     AssertEQ(GetCursorPosition().y(), height)
-    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), [NUL, "a", "b"])
+    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), [empty(), "a", "b"])
 
     # Move down, ensure scroll.
     escio.Write(VT)
     AssertEQ(GetCursorPosition().y(), height)
-    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), ["a", "b", NUL])
+    AssertScreenCharsInRectEqual(Rect(2, height - 2, 2, height), ["a", "b", empty()])
 
   @vtLevel(4)
   def test_VT_ScrollsInTopBottomRegionStartingAbove(self):
@@ -51,7 +51,7 @@ class VTTests(object):
     escio.Write(VT)
     escio.Write(VT)
     AssertEQ(GetCursorPosition(), Point(2, 5))
-    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", NUL])
+    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", empty()])
 
   @vtLevel(4)
   def test_VT_ScrollsInTopBottomRegionStartingWithin(self):
@@ -64,7 +64,7 @@ class VTTests(object):
     escio.Write(VT)
     escio.Write(VT)
     AssertEQ(GetCursorPosition(), Point(2, 5))
-    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", NUL])
+    AssertScreenCharsInRectEqual(Rect(2, 4, 2, 5), ["x", empty()])
 
   @vtLevel(4)
   def test_VT_MovesDoesNotScrollOutsideLeftRight(self):


### PR DESCRIPTION
add/use esc.empty() to return the "right" checksum value for cells that were
erased as opposed to having an explicit space written.  xterm #334 changes the behavior from NUL to space.