### PR TITLE
Incorporate updates from xterm #336 and vttest 20180911

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -145,6 +145,24 @@ The logs are written to "file", which defaults to "/tmp/esctest.log".
 --timeout=timeout
 The number of seconds to wait for a response from the terminal. Defaults to 1.
 
+--xterm-checksum[=patchnumber]
+  The patch numbers are part of $XTERM_VERSION, allowing them to be scripted.
+  Xterm #279 implemented DECRQCRA; DEC's documentation omits details.
+  Xterm #334 modified the checksum calculation to treat all blanks equally.
+  Xterm #336 changed the default behavior for DECRQCRA to match DEC's actual
+  calculation, as well as providing a resource setting checksumExtension which
+  makes xterm match the earlier versions.  These options adjust the calculation
+  in esctest to correspond with those versions.  If neither is set, and the
+  expected-term is "xterm", esctest should expect DEC's calculation.  By
+  coincidence, DEC's terminals treat blanks similarly to xterm #279, but there
+  are additional complications.
+  To make xterm match the calculation for xterm #334,
+  set the following resource:
+    xterm*checksumExtension: 23
+  To make xterm match the calculation for xterm #279,
+  set the following resource:
+    xterm*checksumExtension: 31
+
 --v=verbosity
 Verbosity level for logging. The following levels are defined:
 * 1: Errors only.

--- a/esctest/esc.py
+++ b/esctest/esc.py
@@ -20,13 +20,18 @@ vtLevel = 1
 
 # xterm distinguishes "blanks" (cells where a space was written) from empty
 # space (after an erase) to use that in selection.  DEC's documentation does
-# not have anything analogous.  These scripts use DECRQCRA to guess what a
-# given cell contains, and make the assumption that a NUL corresponds to the
-# latter.  However, xterm patch #334 changes DECRQCRA for better consistency
-# with the documentation, and computes empty and blank cells as if both hold
-# a space.
+# not have anything analogous (although screenshots demonstrate that it gives a
+# similar result).  These scripts use DECRQCRA to guess what a given cell
+# contains, and make the assumption that a NUL corresponds to the latter. 
+#
+# The checksum computation in xterm patch #279 kept the distinction, returning
+# zero for cells which were empty.  xterm patch #334 changed DECRQCRA for
+# better consistency with the existing documentation, and computed empty
+# and blank cells as if both hold a space.  This function assumes that the
+# terminal has been set up to use that convention if the --xterm-checksum=334
+# option was given.
 def empty():
-  if escargs.args.expected_terminal == "xterm":
+  if escargs.args.xterm_checksum >= 334:
     return ' '
   else:
     return NUL

--- a/esctest/escargs.py
+++ b/esctest/escargs.py
@@ -40,6 +40,10 @@ parser.add_argument("--max-vt-level",
 parser.add_argument("--logfile",
                     help="Log file to write output to",
                     default="/tmp/esctest.log")
+parser.add_argument("--xterm-checksum",
+                    help="Specify version-specific xterm checksum calculation.",
+                    type=int,
+                    default=0)
 parser.add_argument("--v",
                     help="Verbosity level. 1=errors, 2=errors and info, 3=debug, errors, and info",
                     default=2,

--- a/esctest/esccmd.py
+++ b/esctest/esccmd.py
@@ -1,6 +1,5 @@
 from esc import ESC
 from escutil import AssertVTLevel
-import escargs
 import escio
 
 # DECSET/DECRESET

--- a/esctest/escio.py
+++ b/esctest/escio.py
@@ -1,4 +1,4 @@
-from esc import ESC, ST
+from esc import ESC, BEL, ST
 import escargs
 from esclog import LogDebug
 import esctypes
@@ -59,8 +59,6 @@ def DCS():
 def WriteOSC(params, bel=False, requestsReport=False):
   str_params = map(str, params)
   joined_params = ";".join(str_params)
-  ST = ESC + "\\"
-  BEL = chr(7)
   if bel:
     terminator = BEL
   else:

--- a/esctest/escutil.py
+++ b/esctest/escutil.py
@@ -239,6 +239,14 @@ def AssertScreenCharsInRectEqual(rect, expected_lines):
                                              top=point.y(),
                                              right=point.x(),
                                              bottom=point.y()))
+    # esctest is only asking for one cell at a time, which simplifies things.
+    if escargs.args.expected_terminal == "xterm":
+      if escargs.args.xterm_checksum < 279:
+        actual_checksum = 0x10000 - actual_checksum
+        # DEC terminals trim trailing blanks
+        if expected_checksum == 0 and actual_checksum == 32:
+          actual_checksum = 0
+
     if len(actual) <= y:
       actual.append("")
     if actual_checksum == 0:

--- a/esctest/tests/cht.py
+++ b/esctest/tests/cht.py
@@ -1,6 +1,6 @@
 import esccmd
 from esctypes import Point
-from escutil import AssertEQ, GetCursorPosition, knownBug, vtLevel
+from escutil import AssertEQ, GetCursorPosition, vtLevel
 
 class CHTTests(object):
   def test_CHT_OneTabStopByDefault(self):

--- a/esctest/tests/decfi.py
+++ b/esctest/tests/decfi.py
@@ -22,7 +22,7 @@ was at the right edge of the page, the command is ignored.
 from esc import empty
 import esccmd
 import escio
-from escutil import AssertEQ, AssertScreenCharsInRectEqual, GetCursorPosition, GetScreenSize, Point, Rect, intentionalDeviationFromSpec, knownBug, vtLevel
+from escutil import AssertEQ, AssertScreenCharsInRectEqual, GetCursorPosition, GetScreenSize, Point, Rect, knownBug, vtLevel
 
 class DECFITests(object):
   """Move cursor forward or scroll data within margins right."""


### PR DESCRIPTION
	* README.txt: document --xterm-checksum

	* escargs.py: add --xterm-checksum option

	* esc.py: modify empty() to use option --xterm-checksum

	* escutil.py:
	if xterm is (expected to) return DEC-compatible checksums, transform the
	result to make it compatible with esctest's assumptions.

	* escio.py, tests/cht.py, esccmd.py, tests/decfi.py: pylint fixes